### PR TITLE
Bump s4u/setup-maven-action from 1.14.0 to 1.18.0

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,7 +18,7 @@ jobs:
         java_version: [8]
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.14.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test JDK ${{ matrix.java_version }}
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.14.0
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           checkout-fetch-depth: 0
           java-version: ${{ matrix.java_version }}


### PR DESCRIPTION
Version `1.14.0` uses deprecated `actions/cache` version leading to failing actions ([example](https://github.com/joelittlejohn/jsonschema2pojo/actions/runs/15832685486)):

> This request has been automatically failed because it uses a deprecated version of `actions/cache: 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`